### PR TITLE
Bugfix UI

### DIFF
--- a/gears-ui/src/main/java/com/oddy/gearsui/GearsOtpField.kt
+++ b/gears-ui/src/main/java/com/oddy/gearsui/GearsOtpField.kt
@@ -24,6 +24,12 @@ class GearsOtpField @JvmOverloads constructor(
     private var fieldNum: Int = 0
     private var margin: Int = 0
 
+    var invalid = false
+        set(value) {
+            field = value
+            buildItems()
+        }
+
     private fun initAttributes(context: Context, attrs: AttributeSet?) {
         context.theme.obtainStyledAttributes(
             attrs,
@@ -52,19 +58,25 @@ class GearsOtpField @JvmOverloads constructor(
         for (i in 0 until fieldNum) {
             val view = LayoutInflater.from(context)
                 .inflate(R.layout.layout_gears_otp_field_item, this, false) as GearsOtpEditText
-            view.doOnTextChanged { _, _, before, count ->
-                onTextChanged(before, count, i)
-            }
+
+            val backgroundDrawable =
+                if (invalid) R.drawable.bg_gears_otp_error
+                else R.drawable.bg_gears_otp_bg
+            view.setBackgroundResource(backgroundDrawable)
+            view.doOnTextChanged { _, _, before, count -> onTextChanged(before, count, i) }
             view.setOnKeyListener { _, _, event ->
                 if (onKeyBackwardCheck(event, i)) {
                     return@setOnKeyListener true
                 }
+
                 if (onKeyForwardCheck(event, i)) {
                     return@setOnKeyListener true
                 }
+
                 if (event.action == KeyEvent.ACTION_UP) {
                     return@setOnKeyListener onKeyActionUp(event, i)
                 }
+
                 false
             }
             addView(view)

--- a/gears-ui/src/main/res/drawable/bg_gears_otp_error.xml
+++ b/gears-ui/src/main/res/drawable/bg_gears_otp_error.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <stroke android:color="@color/ui_red" android:width="1dp" />
+    <corners android:radius="@dimen/gears_otp_radius" />
+</shape>

--- a/gears-ui/src/main/res/values/dimens.xml
+++ b/gears-ui/src/main/res/values/dimens.xml
@@ -25,7 +25,7 @@
     <dimen name="gears_button_padding_horizontal_large">16dp</dimen>
     <dimen name="gears_button_padding_vertical_large">13dp</dimen>
     <dimen name="gears_button_corner_radius">16dp</dimen>
-    <dimen name="gears_button_border_size">1dp</dimen>
+    <dimen name="gears_button_border_size">2dp</dimen>
 
     <dimen name="gears_circular_button_corner_radius">100dp</dimen>
     <dimen name="gears_circular_button_size_xs">32dp</dimen>


### PR DESCRIPTION
## FIXED
1. [Input field outline & otp code's color should changed to red #DB5A52 when otp is invalid](https://app.clickup.com/t/26vcmm3)
2. [Button's outline looks thin.](https://app.clickup.com/t/26vg5a6)