### PR TITLE
Set Max Line Title Toolbar to 2 Lines

### DIFF
--- a/gears-ui/src/main/java/com/oddy/gearsui/compose/GearsToolbar.kt
+++ b/gears-ui/src/main/java/com/oddy/gearsui/compose/GearsToolbar.kt
@@ -115,6 +115,7 @@ fun GearsToolbar(
             GearsText(
                 modifier = Modifier.align(Alignment.CenterHorizontally),
                 text = title.orEmpty(),
+                maxLines = 2,
                 type = GearsTextType.Heading18,
                 textColor = colorResource(id = color)
             )


### PR DESCRIPTION
## FIXED
1. [[New Order Flow][Choose Package]:Set title alignment to center,  and maxline 2 to prevent overflow.](https://app.clickup.com/t/2hyaxaa)